### PR TITLE
Allow host server to be specified

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url" : "http://github.com/hipchat/hubot-hipchat.git"
   },
   "dependencies": {
-    "wobot": "0.3.1"
+    "wobot": "0.4.0"
   },
   "devDependencies": {
     "coffee-script": "1.1.3"

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -22,9 +22,10 @@ class HipChat extends Adapter
       password: process.env.HUBOT_HIPCHAT_PASSWORD
       rooms:    process.env.HUBOT_HIPCHAT_ROOMS or "@All"
       debug:    process.env.HUBOT_HIPCHAT_DEBUG or false
+      host:     process.env.HUBOT_HIPCHAT_HOST or null
 
     console.log "Options:", @options
-    bot = new Wobot(jid: @options.jid, name: @options.name, password: @options.password, debug: @options.debug == 'true')
+    bot = new Wobot(jid: @options.jid, name: @options.name, password: @options.password, debug: @options.debug == 'true', host: @options.host)
     mention = new RegExp("@#{@options.name.split(' ')[0]}\\b", "i")
     console.log mention
     console.log "Bot:", bot
@@ -84,11 +85,12 @@ class HipChat extends Adapter
 
   request: (method, path, body, callback) ->
     console.log method, path, body
-    headers = "Host": "api.hipchat.com"
+    host = @options.host or "api.hipchat.com"
+    headers = "Host": host
 
     options =
       "agent"  : false
-      "host"   : "api.hipchat.com"
+      "host"   : host
       "port"   : 443
       "path"   : path
       "method" : method


### PR DESCRIPTION
This is mainly so I can test changes that require server changes using my dev environment. Wobot 0.4.0 added support for host configuration on init.

I realize I have commit rights to the main repo but I'm new to node, CoffeeScript, and npm package management so I'd love to get stuff checked over. :) Have some good great improvements planned once I get the hang of things.
