### PR TITLE
Fix for recent HipChat in Janky: Ensure User instances have a room attribute like default Campfire adapter

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -149,7 +149,7 @@ class HipChat extends Adapter
     return jid.match(/_(\d+)@/)[1]
 
   roomNameFromJid: (jid) ->
-    return jid.match(/_(\w+)@/)[1]
+    return jid.match(/^\d+_([\w_\.]+)@/)[1]
 
 exports.use = (robot) ->
   new HipChat robot


### PR DESCRIPTION
A disconnect is happening because hubot-hipchat uses the [HipChat XMPP interface](https://www.hipchat.com/help/category/xmpp) and this new Janky HipChat support is using the [HipChat REST API](https://www.hipchat.com/docs/api).

The [User objects in Hubot](https://github.com/github/hubot/blob/master/src/user.coffee) are free-form hashes with instances being created by the respective adapters with the only standard key being `name`.

The User instances [created by the hubot-hipchat adapter have a 'reply_to' attribute](https://github.com/hipchat/hubot-hipchat/blob/master/src/hipchat.coffee#L69) instead of the ['room' attribute the User instances from the campfire adapter have](https://github.com/github/hubot/blob/master/src/adapters/campfire.coffee#L38).

Fix is to add this extra 'room' attribute and set it to the room name (i.e. something like 'Dev') since this is what Janky is expecting to pass around (vs a JID like 7557_dev@conf.hipchat.com) and also what the HipChat REST API is expecting.  We can easily infer the room name from a JID.  For instnace a JID of `7557_dev@conf.hipchat.com` has a room name of `dev`.
