### PR TITLE
I was getting errors like this:

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -1,5 +1,5 @@
-Robot   = require('hubot').robot()
-Adapter = require('hubot').adapter()
+Robot   = require '../../../src/robot'
+Adapter = require '../../../src/adapter'
 
 HTTPS   = require 'https'
 Wobot   = require('wobot').Bot


### PR DESCRIPTION
root@vps:/opt/hubot# /opt/hubot/bin/hubot -a hipchat -n "Rupert Bot"
[Fri, 10 Feb 2012 05:27:08 GMT] ERROR Cannot load adapter hipchat - Error: Cannot find module 'hubot'
[Fri, 10 Feb 2012 05:27:08 GMT] INFO Loading scripts from /opt/hubot/scripts
[Fri, 10 Feb 2012 05:27:08 GMT] INFO Loading scripts from /opt/hubot/src/scripts
TypeError: Cannot call method 'run' of null
    at Robot.run (/opt/hubot/src/robot.coffee:290:27)
    at Object.<anonymous> (/opt/hubot/bin/hubot:102:11)
    at Object.<anonymous> (/opt/hubot/bin/hubot:105:4)
    at Module._compile (module.js:402:26)
    at Object.run (/root/local/node/lib/node_modules/coffee-script/lib/coffee-script/coffee-script.js:68:25)
    at /root/local/node/lib/node_modules/coffee-script/lib/coffee-script/command.js:135:29
    at /root/local/node/lib/node_modules/coffee-script/lib/coffee-script/command.js:110:18
    at [object Object].<anonymous> (fs.js:107:5)
    at [object Object].emit (events.js:61:17)
    at afterRead (fs.js:878:12)

They went away afterI made this change.
