### PR TITLE
Emit connected event

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -85,6 +85,8 @@ class HipChat extends Adapter
     bot.connect()
 
     @bot = bot
+    
+    self.emit "connected"
 
   # Convenience HTTP Methods for posting on behalf of the token"d user
   get: (path, callback) ->


### PR DESCRIPTION
The newest version of Hubot wants to see the connected event before it will load listeners.  
