### PR TITLE
Switch reply to use mention name

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -11,7 +11,7 @@ class HipChat extends Adapter
 
   reply: (user, strings...) ->
     for str in strings
-      @send user, "@#{user.name.replace(' ', '')} #{str}"
+      @send user, "@#{user.mention_name} #{str}"
 
   run: ->
     self = @


### PR DESCRIPTION
When replying it'd be good to use the user's real mention name (or @ name), not just a guess based on their real name.
