### PR TITLE
handle no user.mention_name in reply gracefully

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -12,8 +12,11 @@ class HipChat extends Adapter
       @bot.message user.reply_to, str
 
   reply: (user, strings...) ->
-    for str in strings
-      @send user, "@#{user.mention_name} #{str}"
+    if user.mention_name?
+      for str in strings
+        @send user, "@#{user.mention_name} #{str}"
+    else
+      @send user, strings
 
   run: ->
     self = @


### PR DESCRIPTION
We are using this plugin for our company but none of our users have a mention_name attribute.  There is probably a bigger issue causing this but for now it would be nice to not print the mention_name if it doesn't exist so there aren't a bunch of @undefined references.
