### PR TITLE
Update to node-expat 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "http://github.com/hipchat/hubot-hipchat.git"
   },
   "dependencies": {
-    "node-expat": "1.6.1",
+    "node-expat": "2.0.0",
     "wobot": "0.8.0"
   },
   "license": "MIT",


### PR DESCRIPTION
The 2.0.0 version of node-expat bundles the libexpat dependency (https://github.com/astro/node-expat/pull/48) which makes it easier for both Windows / Unix users to get node-expat installed.

Here's a link to the full diff between node-expat v1.6.1 and v2.0.0 - https://github.com/astro/node-expat/compare/v1.6.1...v2.0.0
