### PR TITLE
Makes `send` compatible with `robot.catchAll`

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -16,7 +16,7 @@ class HipChat extends Adapter
       user = envelope
     else
       # expand envelope
-      user = envelope.user
+      user = envelope.user or envelope.message.message.user
       room = envelope.room
 
     if user


### PR DESCRIPTION
For some reason when sending a message in a `robot.catchAll` the `envelope.user` property is not set correctly. This information is available in the `envelope.message.message.user` property however.

This is a simple fix, although I don't fully understand why the envelope isn't being populated correctly in this instance and there's certainly a possibility there is a nicer solution for this.
