### PR TITLE
Fix 'convenience HTTP methods' to work with HipChat API

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -186,19 +186,13 @@ class HipChat extends Adapter
       "agent"  : false
       "host"   : host
       "port"   : 443
-      "path"   : path
+      "path"   : path += "?auth_token=#{@options.token}"
       "method" : method
       "headers": headers
 
     if method is "POST"
-      body.auth_token = @options.token
-      body = JSON.stringify(body)
-      headers["Content-Type"] = "application/json"
-
-      body = new Buffer(body)
+      headers["Content-Type"] = "application/x-www-form-urlencoded"
       options.headers["Content-Length"] = body.length
-    else
-      options.path += "?auth_token=#{@options.token}"
 
     request = HTTPS.request options, (response) ->
       data = ""


### PR DESCRIPTION
Looks like the API changed since these convenience methods were written.

My motivation is that the API gives the ability to send HTML formatted messages.

It's likely a job for Hubot core but it would also be cool if there was a flag that could be set to let plugins know if the adapter supports HTML formatting in its messages. The HipChat adapter could then have an option where, if enabled, Hubot's response.send method would be overridden to send messages via the API instead of XMPP.
