### PR TITLE
Fixes issue #73

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -58,7 +58,7 @@ class HipChat extends Adapter
 
     # create Wobot bot object
     bot = new Wobot(
-      jid: "#{@options.jid}@chat.hipchat.comg/bot",
+      jid: "#{@options.jid}@chat.hipchat.com/bot",
       password: @options.password,
       debug: @options.debug == 'true',
       host: @options.host


### PR DESCRIPTION
Wobot (or Hipchat XMPP gateway), expect the client to set its ressource in order to respect XMPP protocol. hipchat adapter should take this into account.

An alternative would be to update the documentation to set properly HIPCHAT_JIG with a resource like "my_jabber_id@chat.hipchat.com/bot".

Hope it helps.
