### PR TITLE
Lowercase the robot's name

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -69,7 +69,7 @@ class HipChat extends Adapter
       console.log "Connected to HipChat as @#{bot.mention_name}!"
 
       # Provide our name to Hubot
-      self.robot.name = bot.mention_name
+      self.robot.name = bot.mention_name.toLowerCase()
 
       # Tell Hubot we're connected so it can load scripts
       self.emit "connected"


### PR DESCRIPTION
The robot.name should be lowercase. Other scripts normalize this.

An Example:
https://github.com/github/hubot/blob/master/src/scripts/roles.coffee#L57
