### PR TITLE
Fix out of sync names in brain

### DIFF
--- a/src/connector.coffee
+++ b/src/connector.coffee
@@ -448,8 +448,9 @@ onStanza = (stanza) ->
     jid = new xmpp.JID stanza.attrs.from
     room = jid.bare().toString()
     return if not room
-    # name = stanza.attrs.from.split("/")[1]
-    # return if not name
+    name = stanza.attrs.from.split("/")[1]
+    # Fall back to empty string if name isn't reported in presence
+    name ?= ""
     type = stanza.attrs.type or "available"
     x = stanza.getChild "x", "http://jabber.org/protocol/muc#user"
     return if not x
@@ -458,11 +459,9 @@ onStanza = (stanza) ->
     from = entity.attrs?.jid
     return if not from
     if type is "unavailable"
-      @emit "leave", from, room
-      # @emit "leave", from, name, room
+      @emit "leave", from, room, name
     else if type is "available" and entity.attrs.role is "participant"
-      @emit "enter", from, room
-      # @emit "enter", from, name, room
+      @emit "enter", from, room, name
 
 # DOM helpers
 

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -125,17 +125,19 @@ class HipChat extends Adapter
           message: message
           reply_to: from
 
-      changePresence = (PresenceMessage, user_jid, room_jid) =>
+      changePresence = (PresenceMessage, user_jid, room_jid, currentName) =>
         # buffer presence events until the roster fetch completes
         # to ensure user data is properly loaded
         init.done =>
           user = @robot.brain.userForId(@userIdFromJid(user_jid)) or {}
           if user
             user.room = room_jid
+            # If an updated name was sent as part of a presence, update it now
+            user.name = currentName if currentName.length
             @receive new PresenceMessage(user)
 
-      connector.onEnter (user_jid, room_jid) =>
-        changePresence EnterMessage, user_jid, room_jid
+      connector.onEnter (user_jid, room_jid, currentName) =>
+        changePresence EnterMessage, user_jid, room_jid, currentName
 
       connector.onLeave (user_jid, room_jid) ->
         changePresence LeaveMessage, user_jid, room_jid


### PR DESCRIPTION
I've been running this bot for a while and one of the things we've noticed is that @ messages to the bot inside muc no longer work if a user has changed their name. These changes will send a name as part of the presence events (was previously commented out) but as the last parameter. The brain name will only be updated if a name has been provided (I tested with another hipchat bot which has a null name on room join).
