### PR TITLE
Update version of node-xmpp defined in package.json - Fixes #121

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "main": "./src/hipchat",
   "dependencies": {
-    "node-xmpp": "~0.3.2",
+    "node-xmpp": "~0.7.1",
     "underscore": "~1.4.4",
     "rsvp": "~1.2.0"
   }


### PR DESCRIPTION
Fixes this error (which stops hubot from starting up):

```
[Tue Oct 15 2013 21:39:42 GMT-0700 (PDT)] INFO Connecting HipChat adapter...

/Users/anonymous/codes/projects/hubot/node_modules/hubot-hipchat/node_modules/node-xmpp/lib/xmpp/connection.js:277
    this.socket.end();
                ^
TypeError: Cannot call method 'end' of undefined
  at Client.Connection.onEnd (/Users/anonymous/codes/projects/hubot/node_modules/hubot-hipchat/node_modules/node-xmpp/lib/xmpp/connection.js:277:17)
  at CleartextStream.<anonymous> (/Users/anonymous/codes/projects/hubot/node_modules/hubot-hipchat/node_modules/node-xmpp/lib/xmpp/connection.js:56:14)
  at CleartextStream.EventEmitter.emit (events.js:117:20)
  at _stream_readable.js:920:16
  at process._tickCallback (node.js:415:13)
```
