### PR TITLE
Pass xmpp.Element object instead of " " on @jabber.send for ping keepalive

### DIFF
--- a/src/connector.coffee
+++ b/src/connector.coffee
@@ -387,7 +387,7 @@ onOnline = ->
   @setAvailability "chat"
 
   ping = =>
-    @jabber.send " "
+    @jabber.send new xmpp.Element('r')
     @emit "ping"
 
   @keepalive = setInterval ping, 30000


### PR DESCRIPTION
When the arg passed to ping is an empty string a TypeError: Object has no method 'root'
is raised within session.js of the node node-xmpp module. Since the basic premise
of the ping method is to simply perform a keepalive, send through a new xmpp.Element
object instead of an empty string. This object has the root() method that the session
send prototype is looking for.
