### PR TITLE
Make it works with HipChat Beta

### DIFF
--- a/src/connector.coffee
+++ b/src/connector.coffee
@@ -221,7 +221,7 @@ module.exports = class Connector extends EventEmitter
   message: (targetJid, message) ->
     parsedJid = new xmpp.JID targetJid
 
-    if parsedJid.domain is @mucHost
+    if parsedJid.domain.match(/^conf\./)
       packet = new xmpp.Element "message",
         to: "#{targetJid}/#{@name}"
         type: "groupchat"


### PR DESCRIPTION
The previous check was bogus when using HipChat Beta (i.e. running
my personal instance of HipChat).
Actually what we're looking after here is if the message is intended
to be sent to a chatroom or to a user.
Chatroom's JID starts with 'conf.', hence the check.

Note that I've tested it on HipChat Beta but not on HipChat On Demand (e.g. hosted version of HipChat)
