### PR TITLE
Make the @ symbol optional in Private Messages

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -149,7 +149,7 @@ class HipChat extends Adapter
         # remove leading @mention name if present and format the message like
         # "name: message" which is what hubot expects
         mention_name = connector.mention_name
-        regex = new RegExp "^@#{mention_name}\\b", "i"
+        regex = new RegExp "^@?#{mention_name}\\b", "i"
         message = "#{mention_name}: #{message.replace regex, ""}"
         handleMessage
           getAuthor: => @robot.brain.userForId(@userIdFromJid from)


### PR DESCRIPTION
Allows Hubot's name to be used in private messages the same way it can be used in a public channel. This can reduce confusion around how to communicate with Hubot.

Closes #136
