### PR TITLE
Update adapter version to 2.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is a HipChat-specific version of the more general [instructions in the Hubo
 
 1. Install `hubot` from npm, if you don't already have it. Note the explicit version reference. The version # of hubot-hipchat is kept in line with hubot. If your hubot's version is greater than hubot-hipchat's, that means it hasn't been tested and may not work!
 
-        % npm install --global coffee-script hubot@v2.6.4
+        % npm install --global coffee-script hubot@v2.7.2
 
 1. Create a new `hubot` if necessary:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-hipchat",
-  "version": "2.6.4",
+  "version": "2.7.2",
   "author": "HipChat <support@hipchat.com>",
   "description": "A Hipchat adapter for Hubot",
   "keywords": [


### PR DESCRIPTION
#### What? Why?
- Updates adapter to use the latest version of Hubot, 2.7.2.
#### How was it tested?

Starting from scratch using the guide, I set up and fully configured a new Hubot Hipchat instance. No errors occurred during the process.
