### PR TITLE
Make hubot-hipchat self hosting

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   "license": "MIT",
   "main": "./src/hipchat",
   "dependencies": {
+    "hubot": "*",
+    "async": "*",
     "node-xmpp": "~0.12.0",
     "underscore": "~1.4.4",
     "rsvp": "~1.2.0"

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -1,4 +1,4 @@
-{Adapter, TextMessage, EnterMessage, LeaveMessage, User} = require "../../hubot"
+{Adapter, TextMessage, EnterMessage, LeaveMessage, User} = require "hubot"
 HTTPS = require "https"
 {inspect} = require "util"
 Connector = require "./connector"


### PR DESCRIPTION
For some reason, I need this module `hubot-hipchat` to be self hosting, i.e dont assumed that it always installed alone side with a `hubot` module.

So I made `hubot` as the dependency of `hubot-hipchat`, make it no longer relied on that assumption.

During the testing, I had an error said that it missing package `async`, so I add that package as well. If I am wrong on this , please correct me.
