### PR TITLE
Create a copy of the user object so future messages don't update the room or reply_to information

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -165,7 +165,7 @@ class HipChat extends Adapter
         # to ensure user data is properly loaded
         init.done =>
           {getAuthor, message, reply_to, room} = opts
-          author = getAuthor() or {}
+          author = Object.create(getAuthor()) or {}
           author.reply_to = reply_to
           author.room = room
           @receive new TextMessage(author, message)


### PR DESCRIPTION
For #175. 

We've been running with this code since it was committed and haven't experienced any issues.
