### PR TITLE
Transform colon style emoticons to parentheses

### DIFF
--- a/src/connector.coffee
+++ b/src/connector.coffee
@@ -232,6 +232,7 @@ module.exports = class Connector extends EventEmitter
     # based on http://unix.stackexchange.com/questions/111899/how-to-strip-color-codes-out-of-stdout-and-pipe-to-file-and-stdout
     message = message.replace(/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]/g, "")  # remove bash color codes
     message = message.replace(/&/g, "&amp;")                                  # Replacing &
+    message = message.replace(/:(\w+):/g, "($1)")                             # To paren emoticons
     @logger.debug 'building message'
     @logger.debug message
     packet.c("body").t(message)


### PR DESCRIPTION
I've noticed some plugins/scripts using the colon style syntax for emoticons and I thought the HipChat adapter should convert them. No one should ever be without emoticons. :)

Namely, `hubot-pager-me`:

![hipchat](https://cloud.githubusercontent.com/assets/75132/4833549/9bec3836-5fa5-11e4-9573-705eb7831c25.png)

`:boom:  => (boom)`

```
> b = ":boom:"
':boom:'
> b.replace(/:(\w+):/g, "($1)")
'(boom)'
> b = "This: thing works :boom:"
'This: thing works :boom:'
> b.replace(/:(\w+):/g, "($1)")
'This: thing works (boom)'
> b = "This: :indeed: thing works :boom:"
'This: :indeed: thing works :boom:'
> b.replace(/:(\w+):/g, "($1)")
'This: (indeed) thing works (boom)'
> b = "This: :indeed: :work corr: ectly :boom:"
'This: :indeed: :work corr: ectly :boom:'
> b.replace(/:(\w+):/g, "($1)")
'This: (indeed) :work corr: ectly (boom)'
```
