### PR TITLE
Merge users instead of deleting

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -104,7 +104,7 @@ class HipChat extends Adapter
 
       if @options.reconnect
         @waitAndReconnect()
-    
+
     firstTime = true
     connector.onConnect =>
       @logger.info "Connected to #{host} as @#{connector.mention_name}"
@@ -121,8 +121,12 @@ class HipChat extends Adapter
         # Save users to brain
         for user in users
           user.id = @userIdFromJid user.jid
-          # userForId will not overwrite an existing user
+          # userForId will not merge to an existing user
           if user.id of @robot.brain.data.users
+            oldUser = @robot.brain.data.users[user.id]
+            for key, value of oldUser
+              unless key of user
+                user[key] = value
             delete @robot.brain.data.users[user.id]
           @robot.brain.userForId user.id, user
 

--- a/src/test.coffee
+++ b/src/test.coffee
@@ -1,0 +1,7 @@
+
+user = id: 1, name: "yannick"
+oldUser = role: "lol", name: "bob"
+for key, value of oldUser
+  unless key of user
+    user[key] = value
+console.log user, oldUser


### PR DESCRIPTION
At startup, instead of deleting user and adding new one, this PR is merging unexisting keys from old user to the new one before deleting it.

This permits to not lose stuff added to users. Like a lot of scripts do.
