### PR TITLE
Revert "Create a copy of the user object so future messages don't update...

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -171,7 +171,7 @@ class HipChat extends Adapter
         # to ensure user data is properly loaded
         init.done =>
           {getAuthor, message, reply_to, room} = opts
-          author = Object.create(getAuthor()) or {}
+          author = getAuthor() or {}
           author.reply_to = reply_to
           author.room = room
           @receive new TextMessage(author, message)


### PR DESCRIPTION
... the room or reply_to information"

It breaks most scripts with brain using it on msg like

```
msg.message.user.something = otherthing
```

that will update user 
why? I dunno
but `Object.create(getAuthor())` just returns {} for me

This reverts commit 5943e256c7d3a8183a7781eb17899dcac24b9044.
