### PR TITLE
Retrieve users email address from xmpp data

### DIFF
--- a/src/connector.coffee
+++ b/src/connector.coffee
@@ -502,6 +502,8 @@ usersFromStanza = (stanza) ->
     name: el.attrs.name
     # Name used to @mention this user
     mention_name: el.attrs.mention_name
+    # Email address
+    email_address: el.attrs.email
 
 # DOM helpers
 


### PR DESCRIPTION
Can be useful in other scripts.
Since the email address configured in the hipchat account is available in the xmpp response, it's trivial to get it and set the value in the robot brain