### PR TITLE
Remove path assumption

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -1,4 +1,4 @@
-{Adapter, TextMessage, EnterMessage, LeaveMessage, User} = require "../../hubot"
+{Adapter, TextMessage, EnterMessage, LeaveMessage, User} = require "hubot"
 HTTPS = require "https"
 {inspect} = require "util"
 Connector = require "./connector"


### PR DESCRIPTION
The adapter currently assumes that the hubot executable is located in a path 2 steps above the adapter script, however, this may not always be the case, especially in projects that utilize multiple hubots.

Additionally other adapters follow the convention of `require "hubot"` as opposed to `require "../../hubot"`.