### PR TITLE
Updating node-xmpp package to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "license": "MIT",
   "main": "./src/hipchat",
   "dependencies": {
-    "node-xmpp": "~0.12.0",
-    "underscore": "~1.4.4",
-    "rsvp": "~1.2.0"
+    "node-xmpp": "^1.0.0-alpha2",
+    "rsvp": "~1.2.0",
+    "underscore": "~1.4.4"
   }
 }


### PR DESCRIPTION
I was having some issues installing node-xmpp 0.12.0 on Mac OS X 10.10.3. Upgrading the package to the latest available on npm resolved the issues.