### PR TITLE
Ignore private message history messages

### DIFF
--- a/src/connector.coffee
+++ b/src/connector.coffee
@@ -449,6 +449,8 @@ onStanza = (stanza) ->
       # Message without body is probably a typing notification
       body = stanza.getChildText "body"
       return if not body
+      # Ignore chat history
+      return if stanza.getChild "delay"
       fromJid = new xmpp.JID stanza.attrs.from
       @emit "privateMessage", fromJid.bare().toString(), body
 


### PR DESCRIPTION
The bot can get into an infinite recursive loops when receiving an 
API notification sent directly to a user.

Notifications sent by the bot itself via the REST API appear to have
come from the recipient, not the bot itself. These messages have a
"delay" child, so it's easy to ignore them that way similar to how we
ignore groupchat history.