### PR TITLE
Handle object jids in joinRoom

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -139,9 +139,10 @@ class HipChat extends Adapter
           @robot.brain.userForId user.id, user
 
       joinRoom = (jid) =>
-        blacklisted_room_jids = @options.rooms_blacklist.split ","
-
-        if jid in blacklisted_room_jids
+        if jid and typeof jid is "object"
+          jid = "#{jid.local}@#{jid.domain}"
+        
+        if jid in @options.rooms_blacklist.split(",")
           @logger.info "Not joining #{jid} because it is blacklisted"
           return
 


### PR DESCRIPTION
Attempts to fix blacklist failures as described in #235.  May improve other room join scenarios as well.