### PR TITLE
Add HUBOT_HIPCHAT_JOIN_PUBLIC_ROOMS to stop Hubot joining public rooms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ Optional. This is a comma separated list of room JIDs that should not be joined.
 
 Optional. Setting to `false` will prevent the HipChat adapter from auto-joining rooms when invited.
 
+### HUBOT\_HIPCHAT\_JOIN\_PUBLIC\_ROOMS
+
+Optional. Setting to `false` will prevent the HipChat adapter from auto-joining rooms that are publicly available.
+
 ### HUBOT\_HIPCHAT\_HOST
 
 Optional. Use to force the host to open the XMPP connection to.


### PR DESCRIPTION
This fixes https://github.com/hipchat/hubot-hipchat/issues/243, and is turned off by default.

This is working well in our production instance of Hubot.