### PR TITLE
Don't convert & to &amp;, it breaks URLs and is not needed

### DIFF
--- a/src/connector.coffee
+++ b/src/connector.coffee
@@ -228,7 +228,6 @@ module.exports = class Connector extends EventEmitter
     # we should make sure that the message is properly escaped
     # based on http://unix.stackexchange.com/questions/111899/how-to-strip-color-codes-out-of-stdout-and-pipe-to-file-and-stdout
     message = message.replace(/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]/g, "")  # remove bash color codes
-    message = message.replace(/&/g, "&amp;")                                  # Replacing &
     @logger.debug 'building message'
     @logger.debug message
     packet.c("body").t(message)


### PR DESCRIPTION
I assume it's because the node-xmpp library has been updated since the replace line was added, and that now means the encoding of characters is now done inside node-xmpp.