### PR TITLE
Update rooms processing

### DIFF
--- a/src/connector.coffee
+++ b/src/connector.coffee
@@ -137,7 +137,7 @@ module.exports = class Connector extends EventEmitter
         stanza.getChild("query").getChildren("item").map (el) ->
           x = el.getChild "x", "http://hipchat.com/protocol/muc#room"
           # A room
-          jid: el.attrs.jid
+          jid: el.attrs.jid.trim()
           name: el.attrs.name
           id: getInt(x, "id")
           topic: getText(x, "topic")


### PR DESCRIPTION
If a user passing a comma separated HUBOT_HIPCHAT_ROOMS list included a space in the room names (like many people probably do), then the system fails when trying to join the second room because the space is being included in the name.  This ensures that the jid it tries to use is using the "trimmed" version with beginning and ending whitespace removed.