### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This is a HipChat-specific version of the more general [instructions in the Hubo
 
 1. Add [Redis To Go](http://devcenter.heroku.com/articles/redistogo) to your Heroku app:
 
-        % heroku addons:add redistogo:nano
+        % heroku addons:create redistogo:nano --app our-company-hubot
 
 1. Configure it:
 


### PR DESCRIPTION
This instruction needs to be edited because running it as-is emits the following warning:

`WARNING: `heroku addons:add` has been deprecated. Please use `heroku addons:create` instead.`

With the above, one gets:

` !    Couldn't find that app.`

My edit prevents the warning and the error.

