### PR TITLE
Delegates reconnect logic to the XMPP adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "node" : "~0.12.2"
   },
   "dependencies": {
-    "node-xmpp-client": "^1.0.0-alpha20",
-    "node-xmpp-core": "^1.0.0-alpha14",
+    "node-xmpp-client": "^1.0.0-alpha23",
+    "node-xmpp-core": "^1.0.0-alpha23",
     "rsvp": "~1.2.0",
     "underscore": "~1.4.4"
   }

--- a/src/connector.coffee
+++ b/src/connector.coffee
@@ -66,6 +66,7 @@ module.exports = class Connector extends EventEmitter
     @host = options.host
     @caps_ver = options.caps_ver or "hubot-hipchat:#{pkg.version}"
     @xmppDomain = options.xmppDomain
+    @reconnect = options.reconnect
 
     # Multi-User-Conference (rooms) service host. Use when directing stanzas
     # to the MUC service.
@@ -78,7 +79,8 @@ module.exports = class Connector extends EventEmitter
     @jabber = new xmpp.Client
       jid: @jid,
       password: @password,
-      host: @host
+      host: @host,
+      reconnect: @reconnect
 
     @jabber.on "error", bind(onStreamError, @)
     @jabber.on "online", bind(onOnline, @)


### PR DESCRIPTION
The reconnect logic is currently broken, as far as I can tell. Currently, when a disconnect occurs, the onOffline method is invoked, which invokes the disconnect method, which closes the connection, which invokes the onOffline method, etc... until the stack is blown. Log messages look like:

```
[Wed Sep 30 2015 12:15:20 GMT-0400 (EDT)] DEBUG Disconnecting here
[Wed Sep 30 2015 12:15:20 GMT-0400 (EDT)] INFO Connection went offline
[Wed Sep 30 2015 12:15:20 GMT-0400 (EDT)] DEBUG Disconnecting here
[Wed Sep 30 2015 12:15:20 GMT-0400 (EDT)] INFO Connection went offline
[Wed Sep 30 2015 12:15:20 GMT-0400 (EDT)] DEBUG Disconnecting here
[Wed Sep 30 2015 12:15:20 GMT-0400 (EDT)] INFO Connection went offline
[Wed Sep 30 2015 12:15:20 GMT-0400 (EDT)] DEBUG Disconnecting here

undefined:0
(null)

RangeError: Maximum call stack size exceeded
```

In any case, the XMPP client itself has reconnect logic, so I think it makes more sense to delegate the functionality there. It has the effect of resolving the stack overflow issue too.
