### PR TITLE
BOSH server was not actually passed to the connector

### DIFF
--- a/src/connector.coffee
+++ b/src/connector.coffee
@@ -66,6 +66,7 @@ module.exports = class Connector extends EventEmitter
     @host = options.host
     @caps_ver = options.caps_ver or "hubot-hipchat:#{pkg.version}"
     @xmppDomain = options.xmppDomain
+    @bosh = options.bosh
 
     # Multi-User-Conference (rooms) service host. Use when directing stanzas
     # to the MUC service.
@@ -79,6 +80,7 @@ module.exports = class Connector extends EventEmitter
       jid: @jid,
       password: @password,
       host: @host
+      bosh: @bosh
 
     @jabber.on "error", bind(onStreamError, @)
     @jabber.on "online", bind(onOnline, @)

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -90,6 +90,7 @@ class HipChat extends Adapter
       host: @options.host
       logger: @logger
       xmppDomain: @options.xmppDomain
+      bosh: @options.bosh
     host = if @options.host then @options.host else "hipchat.com"
     @logger.info "Connecting HipChat adapter..."
 


### PR DESCRIPTION
Change-Id: Ieabd0efd73d14e313ccdb2e0b05e0bfb10dca6b2

A user can specifiy a BOSH server to be used by setting the HUBOT_HIPCHAT_BOSH_URL environment variable.

This caused the URL to be printed in debug output, but it was not actually passed to the connector or the underlying client. Because of this it was never actually attempted to connect through BOSH, but instead the plain XMPP connection on port 5222 was used.