### PR TITLE
update node-xmpp-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "node" : "~0.12.2"
   },
   "dependencies": {
-    "node-xmpp-client": "^1.0.0-alpha20",
-    "node-xmpp-core": "^1.0.0-alpha14",
+    "node-xmpp-client": "^2.1.0",
     "rsvp": "~1.2.0",
     "underscore": "~1.4.4"
   }

--- a/src/connector.coffee
+++ b/src/connector.coffee
@@ -24,8 +24,6 @@
 fs = require "fs"
 {bind, isString, isRegExp} = require "underscore"
 xmpp = require 'node-xmpp-client'
-xmpp.Element = xmpp.ltx.Element
-xmpp.JID = require('node-xmpp-core').JID
 
 # Parse and cache the node package.json file when this module is loaded
 pkg = do ->


### PR DESCRIPTION
* node-xmpp-core is not needed (and possibly harmful as you possibly could be using a different version as node-xmpp-client)
* node-xmpp-client now installs on Node.js 4

