### PR TITLE
New Functionality: sendHtml and sendFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,8 @@
   "engines": {
     "node": "~0.12.2"
   },
-  "peerDependencies": {
-    "hubot": ">=2.0"
-  },
   "dependencies": {
     "fs": "0.0.2",
-    "hubot": "^2.17.0",
     "mime": "^1.3.4",
     "node-xmpp-client": "^2.1.0",
     "request": "^2.67.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "main": "./src/hipchat",
   "engines": {
-    "node" : "~0.12.2"
+    "node": "~0.12.2"
   },
   "dependencies": {
     "node-xmpp-client": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,12 @@
   "engines": {
     "node": "~0.12.2"
   },
+  "peerDependencies": {
+    "hubot": ">=2.0"
+  },
   "dependencies": {
     "fs": "0.0.2",
+    "hubot": "^2.17.0",
     "mime": "^1.3.4",
     "node-xmpp-client": "^2.1.0",
     "request": "^2.67.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "node": "~0.12.2"
   },
   "dependencies": {
+    "fs": "0.0.2",
+    "mime": "^1.3.4",
     "node-xmpp-client": "^2.1.0",
+    "request": "^2.67.0",
     "rsvp": "~1.2.0",
     "underscore": "~1.4.4"
   }

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -100,7 +100,7 @@ class HipChat extends Adapter
         sendMultipart url, file_info.name + ext, data, mimeType, file_info.msg
 
     else if file_info.data
-      sendMultipart url, file_info.name, data, mimeType, file_info.msg
+      sendMultipart url, file_info.name + ext, data, mimeType, file_info.msg
 
     else
       return @logger.error "ERROR: must specify either data or path for sendFile"
@@ -120,7 +120,7 @@ class HipChat extends Adapter
           'body': data
       ]
 
-    requestLib params, (err, resp, body) ->
+    requestLib.post params, (err, resp, body) ->
           if resp.statusCode > 400
             return @logger.error "Hipchat API errror: #{resp.statusCode}"
 

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -32,20 +32,12 @@ class HipChat extends Adapter
     else
       room # this will happen if someone uses robot.messageRoom(jid, ...)
 
-  getRoomDetails: (envelope) ->
-    jid = @extractJid(envelope)
-
-    if not jid
-      return @logger.error "ERROR: Details for this room do not exist"
-
-    return @room_map[jid]
-
   send: (envelope, strings...) ->
 
     target_jid = @extractJid(envelope)
       
     if not target_jid
-      return @logger.error "Not sure who to send to: envelope=#{inspect envelope}"
+      return @logger.error "ERROR: Not sure who to send to: envelope=#{inspect envelope}"
 
     for str in strings
       @connector.message target_jid, str

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -1,0 +1,11 @@
+{Response} = require 'hubot'
+
+class HipchatResponse extends Response
+
+	sendFile: (file_info) ->
+		@robot.adapter.sendFile(@envelope, file_info)
+
+	sendHtml: (strings...) ->
+		@robot.adapter.sendHtml(@envelope, strings...)
+
+module.exports = HipchatResponse


### PR DESCRIPTION
This pr adds two new features that I really wanted for some scripts that I have been working on. An example script can be found [here](https://github.com/cs10/Alonzo/blob/master/scripts/test_scripts/adapterTest.coffee).

1.``` resp.sendHtml``` uses the hipchat api to send a string as html content to a chat room. This allows bots to do cool things like post tables and hyperlinks

2.) ```resp.sendFile``` uses the hipchat api to send a file to a room. The file can either be a file buffer (result of fs.readFile) or a path. This function takes an object of options as described in hipchat.coffee.

Also:
* Created a HipchatResponse object that overrides the standard robot response. The adapter can add additional functions through this object.
* Users must set an api token to use either of these methods (this is checked)
* I would be happy to update the README if this gets pulled in.  I'm pretty new to node and coffeescript so comments are greatly appreciated!