### PR TITLE
New Features: sendFile and sendHtml

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Bonus: Add a notification hook to Heroku so a notification is sent to a room whe
 robot.messageRoom("1234_room@conf.hipchat.com", "message");
 ```
 
-## hubot-hipchat specific featues
+## Features specific to hubot-hipchat
 
 In addition to the response methods provided by the normal hubot, such as ```resp.send```, hubot-hipchat provides these hipchat specific functions:
 * ```resp.sendHtml``` takes any number of strings and sticks them together as one html message post. For example, you can send a hyperlink by doing this:

--- a/README.md
+++ b/README.md
@@ -91,6 +91,27 @@ Bonus: Add a notification hook to Heroku so a notification is sent to a room whe
 robot.messageRoom("1234_room@conf.hipchat.com", "message");
 ```
 
+## hubot-hipchat specific featues
+
+In addition to the response methods provided by the normal hubot, such as ```resp.send```, hubot-hipchat provides these hipchat specific functions:
+* ```resp.sendHtml``` takes any number of strings and sticks them together as one html message post. For example, you can send a hyperlink by doing this:
+```
+robot.respond /send hyperlink/i, (resp)->
+  resp.sendHtml "<a href='https://hipchat.com'>hipchat site</a>"
+```
+
+* ```resp.sendFile``` takes an object that contains either file data or a path to a file along with other file info and posts the file to a room with an optional message:
+```
+robot.respond /send file/i, (resp) ->
+  file_info =
+    name : "the name people will see in the room"
+    path : 'path/to/file.text'
+    type: "text" # required
+    msg : "optional message to post when file is uploaded"
+
+  resp.sendFile file_info
+```
+
 ## Adapter configuration
 
 This adapter uses the following environment variables:
@@ -134,6 +155,10 @@ Optional. Set to `debug` to enable detailed debug logging.
 ### HUBOT\_HIPCHAT\_RECONNECT
 
 Optional. Seting to `false` will prevent the HipChat adapter from auto-reconnecting if it detects a server error or disconnection.
+
+### HUBOT\_HIPCHAT\_TOKEN
+
+Optional. Set to the value of an API token for HipChat. Generate an API token [here](https://cs10.hipchat.com/account/api) (and give it the necessary scopes to post in rooms, the easiest way is just give it access to all scopes).  This needs to be set in order to use the sendFile and sendHtml methods.
 
 ## Running locally
 

--- a/package.json
+++ b/package.json
@@ -19,12 +19,8 @@
   "engines": {
     "node": "~0.12.2"
   },
-  "peerDependencies": {
-    "hubot": ">=2.0"
-  },
   "dependencies": {
     "fs": "0.0.2",
-    "hubot": "^2.17.0",
     "mime": "^1.3.4",
     "node-xmpp-client": "^2.1.0",
     "request": "^2.67.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "node": "~0.12.2"
   },
   "dependencies": {
-    "fs": "0.0.2",
     "mime": "^1.3.4",
     "node-xmpp-client": "^2.1.0",
     "request": "^2.67.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "main": "./src/hipchat",
   "engines": {
-    "node" : "~0.12.2"
+    "node": "~0.12.2"
   },
   "dependencies": {
     "node-xmpp-client": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,12 @@
   "engines": {
     "node": "~0.12.2"
   },
+  "peerDependencies": {
+    "hubot": ">=2.0"
+  },
   "dependencies": {
     "fs": "0.0.2",
+    "hubot": "^2.17.0",
     "mime": "^1.3.4",
     "node-xmpp-client": "^2.1.0",
     "request": "^2.67.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "node": "~0.12.2"
   },
   "dependencies": {
+    "fs": "0.0.2",
+    "mime": "^1.3.4",
     "node-xmpp-client": "^2.1.0",
+    "request": "^2.67.0",
     "rsvp": "~1.2.0",
     "underscore": "~1.4.4"
   }

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -35,7 +35,6 @@ class HipChat extends Adapter
   send: (envelope, strings...) ->
 
     target_jid = @extractJid(envelope)
-    @logger.info inspect envelope
       
     if not target_jid
       return @logger.error "ERROR: Not sure who to send to: envelope=#{inspect envelope}"

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -100,7 +100,7 @@ class HipChat extends Adapter
         sendMultipart url, file_info.name + ext, data, mimeType, file_info.msg
 
     else if file_info.data
-      sendMultipart url, file_info.name, data, mimeType, file_info.msg
+      sendMultipart url, file_info.name + ext, data, mimeType, file_info.msg
 
     else
       return @logger.error "ERROR: must specify either data or path for sendFile"
@@ -120,7 +120,7 @@ class HipChat extends Adapter
           'body': data
       ]
 
-    requestLib params, (err, resp, body) ->
+    requestLib.post params, (err, resp, body) ->
           if resp.statusCode > 400
             return @logger.error "Hipchat API errror: #{resp.statusCode}"
 

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -35,6 +35,7 @@ class HipChat extends Adapter
   send: (envelope, strings...) ->
 
     target_jid = @extractJid(envelope)
+    @logger.info inspect envelope
       
     if not target_jid
       return @logger.error "ERROR: Not sure who to send to: envelope=#{inspect envelope}"

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -32,20 +32,12 @@ class HipChat extends Adapter
     else
       room # this will happen if someone uses robot.messageRoom(jid, ...)
 
-  getRoomDetails: (envelope) ->
-    jid = @extractJid(envelope)
-
-    if not jid
-      return @logger.error "ERROR: Details for this room do not exist"
-
-    return @room_map[jid]
-
   send: (envelope, strings...) ->
 
     target_jid = @extractJid(envelope)
       
     if not target_jid
-      return @logger.error "Not sure who to send to: envelope=#{inspect envelope}"
+      return @logger.error "ERROR: Not sure who to send to: envelope=#{inspect envelope}"
 
     for str in strings
       @connector.message target_jid, str

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -1,6 +1,6 @@
 {Response} = require 'hubot'
 
-class HipchatResponse extends Response
+class HipChatResponse extends Response
 
 	sendFile: (file_info) ->
 		@robot.adapter.sendFile(@envelope, file_info)
@@ -8,4 +8,4 @@ class HipchatResponse extends Response
 	sendHtml: (strings...) ->
 		@robot.adapter.sendHtml(@envelope, strings...)
 
-module.exports = HipchatResponse
+module.exports = HipChatResponse

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -1,0 +1,11 @@
+{Response} = require 'hubot'
+
+class HipchatResponse extends Response
+
+	sendFile: (file_info) ->
+		@robot.adapter.sendFile(@envelope, file_info)
+
+	sendHtml: (strings...) ->
+		@robot.adapter.sendHtml(@envelope, strings...)
+
+module.exports = HipchatResponse


### PR DESCRIPTION
This pr adds some HipChat specific functionality. Check the updated README for usage, but an example script can also be found [here](https://github.com/cs10/Alonzo/blob/master/scripts/test_scripts/adapterTest.coffee).

This pr adds two new functions to the response object that an executed script receives ```resp.sendHtml``` and ```resp.sendFile```.  There was a bit of a trick to adding these new features as the standard hubot response does not have these features. I extended the hubot Response class with a HipChatResponse object that contains these two new methods. Then when the adapter is initialized it replaces the robot's response object with its own.

Any comments would be greatly appreciated, but I'm sure myself and others would love to see this pulled in as part of the adapter.