### PR TITLE
Bump node-xmpp-client to ^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node" : "~0.12.2"
   },
   "dependencies": {
-    "node-xmpp-client": "^2.1.0",
+    "node-xmpp-client": "^3.0.0",
     "rsvp": "~1.2.0",
     "underscore": "~1.4.4"
   }


### PR DESCRIPTION
`node-xmpp-client` has no binary deps anymore, which makes me :smiley:. As far as I can tell this lib bump Just Works for our Hubot.
