### PR TITLE
Use a normal object when setting up the author object.

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -1,6 +1,7 @@
 {Adapter, TextMessage, EnterMessage, LeaveMessage, TopicMessage, User} = require "hubot"
 HTTPS = require "https"
 {inspect} = require "util"
+_ = require 'underscore'
 Connector = require "./connector"
 promise = require "./promises"
 
@@ -191,7 +192,7 @@ class HipChat extends Adapter
         # to ensure user data is properly loaded
         init.done =>
           {getAuthor, message, reply_to, room} = opts
-          author = Object.create(getAuthor()) or {}
+          author = _.extend({}, getAuthor()) or {}
           author.reply_to = reply_to
           author.room = room
           @receive new TextMessage(author, message)


### PR DESCRIPTION
`Object.create(foo)` produces an object that inherits properties from
`foo`. This isn't necessarily harmful, but it can cause surprising
behaviour:

```
> console.log(msg.message.user)
{ reply_to: 'test_room@conf.btf.hipchat.com',
  room: 'test_room' }
> typeof msg.message.user
"object"
> console.log(msg.message.user.name) // should be undefined, surely?
"Wilfred Hughes"
```

I think this is a worthwhile change as it makes debugging plugins easier.
