### PR TITLE
Revert creating a copy of the user object

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -191,7 +191,7 @@ class HipChat extends Adapter
         # to ensure user data is properly loaded
         init.done =>
           {getAuthor, message, reply_to, room} = opts
-          author = Object.create(getAuthor()) or {}
+          author = getAuthor() or {}
           author.reply_to = reply_to
           author.room = room
           @receive new TextMessage(author, message)


### PR DESCRIPTION
This reverts commit 5943e256c. Found that `Object.create()` seems to
somehow break the underlying user object returned from the brain. Having
a hard time understanding what problems the original commit was trying
to solve. Looked at a few other adapters (Slack, Campfire, Shell) and
none of these try to clone the user object returned by the brain. Also,
have not see any adverse affects in testing.

Found this issue while working with the `hubot-pager-me` plugin. This
plugin assumes the `user` property in `message` is from the brain. When
doing things like `pager me as foo@bar.com` it assigns it to that
property where it should persist but does not due to this bug. This
works fine in the Shell adapter though.