### PR TITLE
Fix the processing of rooms.

### DIFF
--- a/src/connector.coffee
+++ b/src/connector.coffee
@@ -492,13 +492,13 @@ onStanza = (stanza) ->
       @emit event_id, null, stanza
     else if stanza.attrs.type is "set"
       # Check for roster push
-      q = stanza.getChild("query")
+      q = stanza.getChild "query"
       switch q.attrs.xmlns
         when "jabber:iq:roster"
-          users = usersFromStanza(stanza)
+          users = usersFromStanza stanza
           @emit "rosterChange", users, stanza
         when "http://hipchat.com/protocol/muc#room"
-          i = q.getChild("item")
+          i = q.getChild "item"
           jid = i.attrs.jid
           if i.attrs.status == "deleted"
             @emit "roomDeleted", jid
@@ -506,12 +506,12 @@ onStanza = (stanza) ->
           room =
             jid: jid
             name: i.attrs.name
-            id: getInt(i, "id")
-            topic: getText(i, "topic")
-            privacy: getText(i, "privacy")
-            owner: getText(i, "owner")
-            guest_url: getText(i, "guest_url")
-            is_archived: !!getChild(i, "is_archived")
+            id: getInt i, "id"
+            topic: getText i, "topic"
+            privacy: getText i, "privacy"
+            owner: getText i, "owner"
+            guest_url: getText i, "guest_url"
+            is_archived: !!getChild i, "is_archived"
           @emit "roomPushes", room
     else
       # IQ error response

--- a/src/connector.coffee
+++ b/src/connector.coffee
@@ -348,6 +348,8 @@ module.exports = class Connector extends EventEmitter
 
   onRoomPushes: (callback) -> @on "roomPushes", callback
 
+  onRoomDeleted: (callback) -> @on "roomDeleted", callback
+
   # Emitted whenever the connector pings the server (roughly every 30 seconds).
   #
   # - `callback`: Function to be triggered: `function ()`
@@ -479,9 +481,12 @@ onStanza = (stanza) ->
           @emit "rosterChange", users, stanza
         when "http://hipchat.com/protocol/muc#room"
           i = q.getChild("item")
-          return if i.attrs.status == "deleted"
+          jid = i.attrs.jid
+          if i.attrs.status == "deleted"
+            @emit "roomDeleted", jid
+            return
           room =
-            jid: i.attrs.jid
+            jid: jid
             name: i.attrs.name
             id: getInt(i, "id")
             topic: getText(i, "topic")

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -27,6 +27,9 @@ class HipChat extends Adapter
       if user?.search?(/@/) >= 0
         user # allows user to be a jid string
       else
+        user = @robot.brain.userForName room
+        @rooms[room]?.jid or
+        user?.jid or
         room # this will happen if someone uses robot.messageRoom(jid, ...)
 
     if not target_jid
@@ -47,6 +50,9 @@ class HipChat extends Adapter
       if user?.search?(/@/) >= 0
         user # allows user to be a jid string
       else
+        user = @robot.brain.userForName room
+        @rooms[room]?.jid or
+        user?.jid or
         room # this will happen if someone uses robot.messageRoom(jid, ...)
 
     if not target_jid

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -203,6 +203,12 @@ class HipChat extends Adapter
       connector.onRosterChange (users) =>
         saveUsers(users)
 
+      connector.onRoomPushes (room) =>
+        if @options.rooms is "All" or @options.rooms is "@All"
+          if !@rooms[room.jid]
+            joinRoom room.jid
+          @rooms[room.jid] = room
+
       handleMessage = (opts) =>
         # buffer message events until the roster fetch completes
         # to ensure user data is properly loaded

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -240,10 +240,11 @@ class HipChat extends Adapter
           changePresence LeaveMessage, user_jid, room_jid
 
         connector.onInvite (room_jid, from_jid, message) =>
-          setRooms()
           action = if @options.autojoin then "joining" else "ignoring"
           @logger.info "Got invite to #{room_jid} from #{from_jid} - #{action}"
           joinRoom(room_jid) if @options.autojoin
+          connector.getRoom room_jid, (err, room) =>
+            @rooms[room.jid] = room
 
       firstTime = false
     connector.connect()

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -19,19 +19,7 @@ class HipChat extends Adapter
     {user, room} = envelope
     user = envelope if not user # pre-2.4.2 style
 
-    target_jid =
-      # most common case - we're replying to a user in a room or 1-1
-      user?.reply_to or
-      # allows user objects to be passed in
-      user?.jid or
-      if user?.search?(/@/) >= 0
-        user # allows user to be a jid string
-      else
-        user = @robot.brain.userForName room
-        @roomJidFromName room or
-        user?.jid or
-        room # this will happen if someone uses robot.messageRoom(jid, ...)
-
+    target_jid = @targetJid user, room
     if not target_jid
       return @logger.error "ERROR: Not sure who to send to: envelope=#{inspect envelope}"
 
@@ -42,19 +30,7 @@ class HipChat extends Adapter
     {user, room} = envelope
     user = envelope if not user # pre-2.4.2 style
 
-    target_jid =
-      # most common case - we're replying to a user in a room or 1-1
-      user?.reply_to or
-      # allows user objects to be passed in
-      user?.jid or
-      if user?.search?(/@/) >= 0
-        user # allows user to be a jid string
-      else
-        user = @robot.brain.userForName room
-        @roomJidFromName room or
-        user?.jid or
-        room # this will happen if someone uses robot.messageRoom(jid, ...)
-
+    target_jid = @targetJid user, room
     if not target_jid
       return @logger.error "ERROR: Not sure who to send to: envelope=#{inspect envelope}"
 
@@ -281,6 +257,18 @@ class HipChat extends Adapter
     for _, room of @rooms
       if room.name == name
         return room.jid
+
+  targetJid: (user, room) ->
+    # most common case - we're replying to a user in a room or 1-1
+    user?.reply_to or
+    # allows user objects to be passed in
+    user?.jid or
+    if user?.search?(/@/) >= 0
+      user # allows user to be a jid string
+    else
+      @robot.brain.userForName(room)?.jid or
+      @roomJidFromName room or
+      room # this will happen if someone uses robot.messageRoom(jid, ...)
 
   # Convenience HTTP Methods for posting on behalf of the token'd user
   get: (path, callback) ->

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -185,6 +185,9 @@ class HipChat extends Adapter
             joinRoom room.jid
           @rooms[room.jid] = room
 
+      connector.onRoomDeleted (jid) =>
+        delete @rooms[jid]
+
       handleMessage = (opts) =>
         # buffer message events until the roster fetch completes
         # to ensure user data is properly loaded


### PR DESCRIPTION
- Update rename the room name #196 

Can get the name of the after the rename. 
`msg.message.room`
- Join newly created rooms #182 
- Room specified message  #268

`messageRoom` was also to make it work.

Help specifies the private room in the user's name.
https://github.com/hubot-scripts/hubot-help/blob/master/src/help.coffee#L76

Hubot user have only the name.
https://github.com/github/hubot/blob/master/src/user.coffee#L9

So I get the JID from the name.

@rbergman I'd like a merge and npm release!
