### PR TITLE
Get user object from brain that matches the current channel

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -186,6 +186,15 @@ class HipChat extends Adapter
       connector.onRosterChange (users) =>
         saveUsers(users)
 
+      getAuthorForChannel = (from, channel) =>
+        users = @robot.brain.usersForFuzzyName from
+        roomUser = null
+        for user in users
+          if user.room == channel
+            roomUser = user
+            break
+        roomUser
+
       handleMessage = (opts) =>
         # buffer message events until the roster fetch completes
         # to ensure user data is properly loaded
@@ -204,7 +213,7 @@ class HipChat extends Adapter
           regex = new RegExp "^@#{mention_name}\\b", "i"
           message = message.replace regex, "#{mention_name}: "
           handleMessage
-            getAuthor: => @robot.brain.userForName(from) or new User(from)
+            getAuthor: => getAuthorForChannel(from, channel) or new User(from)
             message: message
             reply_to: channel
             room: @roomNameFromJid(channel)


### PR DESCRIPTION
Goal: Fix issues where user exists multiple times in brain with multiple IDs, but not necessarily all pertinent info (like mention_name)

Tests: Manual. There are no unit tests for this project at time of writing.