### PR TITLE
When invited to a room the bot should not join if the room is public

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -159,9 +159,8 @@ class HipChat extends Adapter
             for room in rooms
               if !@options.rooms_join_public && room.guest_url != '' && room.jid == jid
                 @logger.info "Not joining #{room.jid} because it is a public room"
-              else
-                @logger.info "Joining #{jid}"
-                connector.join jid
+                return
+      connector.join jid
       # Fetch user info
       connector.getRoster (err, users, stanza) =>
         return init.reject err if err

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -154,9 +154,14 @@ class HipChat extends Adapter
           @logger.info "Not joining #{jid} because it is blacklisted"
           return
 
-        @logger.info "Joining #{jid}"
-        connector.join jid
-
+        connector.getRooms (err, rooms, stanza) =>
+          if rooms
+            for room in rooms
+              if !@options.rooms_join_public && room.guest_url != '' && room.jid == jid
+                @logger.info "Not joining #{room.jid} because it is a public room"
+              else
+                @logger.info "Joining #{jid}"
+                connector.join jid
       # Fetch user info
       connector.getRoster (err, users, stanza) =>
         return init.reject err if err

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -147,6 +147,7 @@ class HipChat extends Adapter
           @robot.brain.userForId user.id, user
 
       joinRoom = (jid) =>
+        joinroom = 1
         if jid and typeof jid is "object"
           jid = "#{jid.local}@#{jid.domain}"
 
@@ -159,8 +160,8 @@ class HipChat extends Adapter
             for room in rooms
               if !@options.rooms_join_public && room.guest_url != '' && room.jid == jid
                 @logger.info "Not joining #{room.jid} because it is a public room"
-                return
-        connector.join jid
+                joinroom = 0
+        connector.join jid unless joinroom == 0
       # Fetch user info
       connector.getRoster (err, users, stanza) =>
         return init.reject err if err

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -147,7 +147,6 @@ class HipChat extends Adapter
           @robot.brain.userForId user.id, user
 
       joinRoom = (jid) =>
-        @joinroom = 1
         if jid and typeof jid is "object"
           jid = "#{jid.local}@#{jid.domain}"
 
@@ -160,8 +159,10 @@ class HipChat extends Adapter
             for room in rooms
               if !@options.rooms_join_public && room.guest_url != '' && room.jid == jid
                 @logger.info "Not joining #{room.jid} because it is a public room"
-                @joinroom = 0
-        connector.join jid unless @joinroom == 0
+                return
+              else if room.jid == jid
+                connector.join jid
+                return
       # Fetch user info
       connector.getRoster (err, users, stanza) =>
         return init.reject err if err

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -160,7 +160,7 @@ class HipChat extends Adapter
               if !@options.rooms_join_public && room.guest_url != '' && room.jid == jid
                 @logger.info "Not joining #{room.jid} because it is a public room"
                 return
-      connector.join jid
+        connector.join jid
       # Fetch user info
       connector.getRoster (err, users, stanza) =>
         return init.reject err if err

--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -147,7 +147,7 @@ class HipChat extends Adapter
           @robot.brain.userForId user.id, user
 
       joinRoom = (jid) =>
-        joinroom = 1
+        @joinroom = 1
         if jid and typeof jid is "object"
           jid = "#{jid.local}@#{jid.domain}"
 
@@ -160,8 +160,8 @@ class HipChat extends Adapter
             for room in rooms
               if !@options.rooms_join_public && room.guest_url != '' && room.jid == jid
                 @logger.info "Not joining #{room.jid} because it is a public room"
-                joinroom = 0
-        connector.join jid unless joinroom == 0
+                @joinroom = 0
+        connector.join jid unless @joinroom == 0
       # Fetch user info
       connector.getRoster (err, users, stanza) =>
         return init.reject err if err


### PR DESCRIPTION
If you tell hubot not to join public rooms it only applies at start up not when the bot is running, this way the bot will only join a room whilst it is running if the room is not public.
