### PR TITLE
prevent disconnect handler from being called recursively

### DIFF
--- a/src/connector.coffee
+++ b/src/connector.coffee
@@ -70,6 +70,7 @@ module.exports = class Connector extends EventEmitter
     # to the MUC service.
     @mucDomain = "conf.#{if @xmppDomain then @xmppDomain else 'hipchat.com'}"
 
+    @disconnecting = false
     @onError @disconnect
 
   # Connects the connector to HipChat and sets the XMPP event listeners.
@@ -98,12 +99,16 @@ module.exports = class Connector extends EventEmitter
   # Disconnect the connector from HipChat, remove the anti-idle and emit the
   # `disconnect` event.
   disconnect: =>
-    @logger.debug 'Disconnecting here'
-    if @keepalive
-      clearInterval @keepalive
-      delete @keepalive
-    @jabber.end()
-    @emit "disconnect"
+    # since we're going to emit "disconnect" event in the end, we should prevent ourself from handling it here
+    if ! @disconnecting
+      @disconnecting = true
+      @logger.debug 'Disconnecting here'
+      if @keepalive
+        clearInterval @keepalive
+        delete @keepalive
+      @jabber.end()
+      @emit "disconnect"
+      @disconnecting = false
 
   # Fetches our profile info
   #


### PR DESCRIPTION
Hey guys,

I'm really new with pull requests and failed to find any kind of "contributors guide for dumbs" so I will appreciate any help with solving my problem.

Our network connection with our new hipchat server installation is not stable and we're investigating this atm but while this is in progress we have problem described in isssue #255 . I've found out that after some time from emitting "disconnect" even in disconnect handler we come back to disconnect handler. As far as I can see this shouldn't broke anything but will fix my problem.

Thank you in advance.