### PR TITLE
Update send method to bind this

### DIFF
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -14,7 +14,7 @@ class HipChat extends Adapter
   emote: (envelope, strings...) ->
     @send envelope, strings.map((str) -> "/me #{str}")...
 
-  send: (envelope, strings...) ->
+  send: (envelope, strings...) =>
     for str in strings
       @connector.message envelope.room, str
 


### PR DESCRIPTION
Something seems to have broken the `messageRoom` method, which ends up calling `send`. Using the `=>` syntax made the bot work again. This also depends on #304 to keep the disconnects from recursing.